### PR TITLE
added capability to construct histogram with no data

### DIFF
--- a/Statistics/Histograms/Histogram.cs
+++ b/Statistics/Histograms/Histogram.cs
@@ -56,15 +56,25 @@ namespace Statistics.Histograms
 
         #region Constructor
         public Histogram(IData data, double binWidth)
-        {
+        {//need to be able to handle null
             BinWidth = binWidth;
-            Min = Math.Floor(data.Range.Min); //this need not be a integer - it just needs to be the nearest bin start - a function of bin width.
-            Int64 numberOfBins = Convert.ToInt64(Math.Ceiling((data.Range.Max - Min) / binWidth)); 
-            Max = Min + (numberOfBins * binWidth);
-            BinCounts = new double[numberOfBins];
-            AddObservationsToHistogram(data);
-            Range = GetRange(Min, Max);
+            if (data == null)
+            {
+                Min = 0;
+                Max = Min + BinWidth;
+                Int64 numberOfBins = 1;
+                BinCounts = new double[numberOfBins];
+            }
+            else
+            {
+                Min = Math.Floor(data.Range.Min); //this need not be a integer - it just needs to be the nearest bin start - a function of bin width.
+                Int64 numberOfBins = Convert.ToInt64(Math.Ceiling((data.Range.Max - Min) / binWidth));
+                Max = Min + (numberOfBins * binWidth);
+                BinCounts = new double[numberOfBins];
+                AddObservationsToHistogram(data);
 
+            }
+            Range = GetRange(Min, Max);
         }
         #endregion
 

--- a/StatisticsTests/Histograms/HistogramTests.cs
+++ b/StatisticsTests/Histograms/HistogramTests.cs
@@ -199,5 +199,17 @@ namespace StatisticsTests.Histograms
 
         }
 
+        [Theory]
+        [InlineData(.1,1)]
+        public void IsHistogramConstructableWithNullData(double binWidth, double expected)
+        {
+            Histogram histogram = new Histogram(null, binWidth);
+            double[] obsToAdd = new double[1] { .05 };
+            IData data = new Data(obsToAdd);
+            histogram.AddObservationToHistogram(data);
+            double actual = histogram.BinCounts[0];
+            Assert.Equal(expected, actual);
+        }
+
     }
 }


### PR DESCRIPTION
To support the implementation of Histogram in Result in fda-model, we need to be able to construct a histogram without data. This revision adds that capability. 