### PR TITLE
Attempting to get around a Math.NET numerics bug

### DIFF
--- a/Statistics/Distributions/ShiftedGamma.cs
+++ b/Statistics/Distributions/ShiftedGamma.cs
@@ -15,7 +15,11 @@ namespace Statistics.Distributions
             // The Gamma distribution is defined by 2 parameters: 
             //      (1) alpha is the shape parameter 
             //      (2) beta is the rate or inverse scale parameter
-            _Gamma = new MathNet.Numerics.Distributions.Gamma(alpha, 1/beta);
+
+            //attempt to get around a gamma bug
+            double alphaRounded = Math.Round(alpha, 4);
+            double betaRounded = Math.Round(beta, 4);
+            _Gamma = new MathNet.Numerics.Distributions.Gamma(alphaRounded, 1/betaRounded);
             Shift = shift;
         }
 

--- a/Statistics/Distributions/ShiftedGamma.cs
+++ b/Statistics/Distributions/ShiftedGamma.cs
@@ -16,8 +16,11 @@ namespace Statistics.Distributions
             //      (1) alpha is the shape parameter 
             //      (2) beta is the rate or inverse scale parameter
 
-            //attempt to get around a gamma bug
-            _Gamma = new MathNet.Numerics.Distributions.Gamma(alpha, 1/beta);
+            //This is an attempt to get around a gamma bug
+            //See: https://github.com/mathnet/mathnet-numerics/issues/553
+            double alphaRounded = Math.Round(alpha, 6);
+            double betaRounded = Math.Round(beta, 6);
+            _Gamma = new MathNet.Numerics.Distributions.Gamma(alphaRounded, 1/betaRounded);
             Shift = shift;
         }
 
@@ -37,8 +40,8 @@ namespace Statistics.Distributions
 
         internal double InverseCDF(double p)
         {
-            double prob = Math.Round(p, 4);
-            return _Gamma.InverseCumulativeDistribution(prob) + Shift;
+
+            return _Gamma.InverseCumulativeDistribution(p) + Shift;
         }
     }
 }

--- a/Statistics/Distributions/ShiftedGamma.cs
+++ b/Statistics/Distributions/ShiftedGamma.cs
@@ -17,9 +17,7 @@ namespace Statistics.Distributions
             //      (2) beta is the rate or inverse scale parameter
 
             //attempt to get around a gamma bug
-            double alphaRounded = Math.Round(alpha, 4);
-            double betaRounded = Math.Round(beta, 4);
-            _Gamma = new MathNet.Numerics.Distributions.Gamma(alphaRounded, 1/betaRounded);
+            _Gamma = new MathNet.Numerics.Distributions.Gamma(alpha, 1/beta);
             Shift = shift;
         }
 
@@ -39,7 +37,8 @@ namespace Statistics.Distributions
 
         internal double InverseCDF(double p)
         {
-            return _Gamma.InverseCumulativeDistribution(p) + Shift;
+            double prob = Math.Round(p, 4);
+            return _Gamma.InverseCumulativeDistribution(prob) + Shift;
         }
     }
 }

--- a/StatisticsTests/Distributions/LogPearsonIIITests.cs
+++ b/StatisticsTests/Distributions/LogPearsonIIITests.cs
@@ -242,6 +242,5 @@ namespace StatisticsTests.Distributions
             double result = testObj.Skewness;
             Assert.Equal(skew, result, 9);
         }
-
     }
 }


### PR DESCRIPTION
Grasping at straws here. I found a report of a bug where we see the probability throwing an exception because the probability is negative. 

https://github.com/mathnet/mathnet-numerics/issues/553

