### PR TITLE
Bug/lp3

### DIFF
--- a/Statistics/Distributions/LogPearson3.cs
+++ b/Statistics/Distributions/LogPearson3.cs
@@ -134,6 +134,26 @@ namespace Statistics.Distributions
             return IRangeFactory.Factory(pmin, pmax);
 
         }
+        /// <summary>
+        /// Added skew validation that steps around a .NET bug where for skewness !=0 and -.002 < skewness < 0.002, an exception is erroneously thrown. 
+        /// </summary>
+        /// <param name="skew"></param>
+        /// <returns></returns>
+        internal double ValidateSkewness(double skew)
+        {
+            if (skew < .002 && skew > 0)
+            {
+                return 0.002;
+            }
+            else if (skew > -.002 && skew < 0)
+            {
+                return -0.002;
+            }
+            else
+            {
+                return skew;
+            }
+        }
         #region IDistribution Functions
         public double PDF(double x)
         {
@@ -184,20 +204,7 @@ namespace Statistics.Distributions
         public string Requirements(bool printNotes) => RequiredParameterization(printNotes);
         public bool Equals(IDistribution distribution) => string.Compare(Print(), distribution.Print(), StringComparison.InvariantCultureIgnoreCase) == 0 ? true : false;
         #endregion
-        internal double ValidateSkewness(double skew)
-        {
-            if (skew < .002 && skew > 0)
-            {
-                return 0.002;
-            }
-            else if(skew > -.002 && skew < 0)
-            {
-                return -0.002;
-            } else
-            {
-                return skew;
-            }
-        }
+
         internal static string Print(double mean, double sd, double skew, int n) => $"log PearsonIII(mean: {mean.Print()}, sd: {sd.Print()}, skew: {skew.Print()}, sample size: {n.Print()})";
         internal static string RequiredParameterization(bool printNotes = true)
         {

--- a/Statistics/Distributions/LogPearson3.cs
+++ b/Statistics/Distributions/LogPearson3.cs
@@ -63,7 +63,7 @@ namespace Statistics.Distributions
         {
             Mean = mean;
             StandardDeviation = standardDeviation;
-            Skewness = ValidateSkewness(skew);
+            Skewness = skew;
             SampleSize = sampleSize;
             Min = double.NegativeInfinity;
             Max = double.PositiveInfinity;
@@ -73,7 +73,7 @@ namespace Statistics.Distributions
         {
             Mean = mean;
             StandardDeviation = standardDeviation;
-            Skewness = ValidateSkewness(skew);
+            Skewness = skew;
             SampleSize = sampleSize;
             Min = min;
             Max = max;
@@ -133,26 +133,6 @@ namespace Statistics.Distributions
             }
             return IRangeFactory.Factory(pmin, pmax);
 
-        }
-        /// <summary>
-        /// Added skew validation that steps around a .NET bug where for skewness !=0 and -.002 < skewness < 0.002, an exception is erroneously thrown. 
-        /// </summary>
-        /// <param name="skew"></param>
-        /// <returns></returns>
-        internal double ValidateSkewness(double skew)
-        {
-            if (skew < .002 && skew > 0)
-            {
-                return 0.002;
-            }
-            else if (skew > -.002 && skew < 0)
-            {
-                return -0.002;
-            }
-            else
-            {
-                return skew;
-            }
         }
         #region IDistribution Functions
         public double PDF(double x)

--- a/Statistics/Distributions/LogPearson3.cs
+++ b/Statistics/Distributions/LogPearson3.cs
@@ -63,7 +63,7 @@ namespace Statistics.Distributions
         {
             Mean = mean;
             StandardDeviation = standardDeviation;
-            Skewness = skew;
+            Skewness = ValidateSkewness(skew);
             SampleSize = sampleSize;
             Min = double.NegativeInfinity;
             Max = double.PositiveInfinity;
@@ -73,7 +73,7 @@ namespace Statistics.Distributions
         {
             Mean = mean;
             StandardDeviation = standardDeviation;
-            Skewness = skew;
+            Skewness = ValidateSkewness(skew);
             SampleSize = sampleSize;
             Min = min;
             Max = max;
@@ -184,7 +184,20 @@ namespace Statistics.Distributions
         public string Requirements(bool printNotes) => RequiredParameterization(printNotes);
         public bool Equals(IDistribution distribution) => string.Compare(Print(), distribution.Print(), StringComparison.InvariantCultureIgnoreCase) == 0 ? true : false;
         #endregion
-
+        internal double ValidateSkewness(double skew)
+        {
+            if (skew < .002 && skew > 0)
+            {
+                return 0.002;
+            }
+            else if(skew > -.002 && skew < 0)
+            {
+                return -0.002;
+            } else
+            {
+                return skew;
+            }
+        }
         internal static string Print(double mean, double sd, double skew, int n) => $"log PearsonIII(mean: {mean.Print()}, sd: {sd.Print()}, skew: {skew.Print()}, sample size: {n.Print()})";
         internal static string RequiredParameterization(bool printNotes = true)
         {

--- a/Statistics/Distributions/PearsonIII.cs
+++ b/Statistics/Distributions/PearsonIII.cs
@@ -10,7 +10,7 @@ namespace Statistics.Distributions
         /// <summary>
         /// A minimum skewness value based on the PearsonIII class in the William Lehman's Statistics assembly.
         /// </summary>
-        private readonly double _NoSkewness = 0.00001;
+        private readonly double _NoSkewness = 0.002;
         /// <summary>
         /// A minimum standard deviation value based on the Pearson III class in William Lehman's Statistics assembly.
         /// </summary>

--- a/StatisticsTests/Distributions/LogPearsonIIITests.cs
+++ b/StatisticsTests/Distributions/LogPearsonIIITests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using System.Linq;
 using Utilities;
 using Xunit;
 using Statistics;
@@ -106,7 +107,7 @@ namespace StatisticsTests.Distributions
         public void GoodData_Returns_FiniteRange2(double mean, double sd, double skew)
         {
             var testObj = new Statistics.Distributions.LogPearson3(mean, sd, skew);
-           // testObj.CDF();
+            // testObj.CDF();
             Assert.True(testObj.Range.IsFinite());
         }
         [Theory]
@@ -185,7 +186,7 @@ namespace StatisticsTests.Distributions
             double result = testObj.Range.Max;
             double fraction = Math.Abs((output - result) / output);
 
-            Assert.True(fraction<.01);
+            Assert.True(fraction < .01);
         }
         [Theory]
         [InlineData(.33d, 2d, 1d, 0.00023424651174493445)] //USGS-R SMWR
@@ -199,9 +200,9 @@ namespace StatisticsTests.Distributions
             var testObj = new Statistics.Distributions.LogPearson3(mean, sd, skew);
             double result = testObj.Range.Min;
             double fraction = Math.Abs((output - result) / output);
-    
-                Assert.True(fraction < .001);
-     
+
+            Assert.True(fraction < .001);
+
         }
         [Theory]
         [InlineData(.33d, 2d, 1d)]
@@ -243,5 +244,8 @@ namespace StatisticsTests.Distributions
             Assert.Equal(skew, result, 9);
         }
 
+
     }
+
+
 }


### PR DESCRIPTION
In testing, I found that the exception only occurs for very small skewness between -.002 and .002. My fix is imperfect. I added a validation for skewness !=0 where -0.002 < skewness < .002, the skew is revised to -0.002 for negative skewness and 0.002 for positive skewness. 