### PR TITLE
add empty constructor for deterministic

### DIFF
--- a/Statistics/Distributions/Deterministic.cs
+++ b/Statistics/Distributions/Deterministic.cs
@@ -37,11 +37,15 @@ namespace Statistics.Distributions
         public IEnumerable<IMessage> Messages => throw new NotImplementedException();
         #endregion
         [Stored(Name = "Value", type = typeof(double))]
-        public double Value { get; }
+        public double Value { get; set; }
         #region constructor
         public Deterministic(double x)
         {
             Value = x;
+        }
+        public Deterministic()
+        {
+
         }
         #endregion
 


### PR DESCRIPTION
for one of the tool we're using to serialize/deserialize requires an empty constructor to instantiate new distributions. Deterministic didn't have one, So I'm getting exceptions in the viewmodel.

https://github.com/HydrologicEngineeringCenter/fda-statistics/blob/d158c0b03b18cccff100481ce3c0d14af304253c/Statistics/Distributions/IDistributionExtensions.cs#L66