### PR TITLE
making validation classes public for external access

### DIFF
--- a/Statistics/Data.cs
+++ b/Statistics/Data.cs
@@ -7,7 +7,7 @@ using Utilities;
 
 namespace Statistics
 {
-    internal class Data : IData, IValidate<Data>
+    public class Data : IData, IValidate<Data>
     {
         #region Properties
         public IRange<double> Range { get; }

--- a/Statistics/Distributions/Empirical.cs
+++ b/Statistics/Distributions/Empirical.cs
@@ -8,7 +8,7 @@ using Utilities;
 
 namespace Statistics.Distributions
 {
-    class Empirical : IDistribution
+    public class Empirical : IDistribution
     {
         #region Fields 
         private bool _ProbabilitiesWereAcceptedAsExceedance;

--- a/Statistics/Validation/DataValidator.cs
+++ b/Statistics/Validation/DataValidator.cs
@@ -7,7 +7,7 @@ using Utilities;
 
 namespace Statistics.Validation
 {
-    internal class DataValidator : IValidator<Data>
+    public class DataValidator : IValidator<Data>
     {
         public IMessageLevels IsValid(Data entity, out IEnumerable<IMessage> msgs)
         {

--- a/Statistics/Validation/EmpiricalValidator.cs
+++ b/Statistics/Validation/EmpiricalValidator.cs
@@ -9,11 +9,12 @@ using Statistics.Distributions;
 
 namespace Statistics.Validation
 {
-    internal class EmpiricalValidator: IValidator<Distributions.Empirical>
+    public class EmpiricalValidator: IValidator<Distributions.Empirical>
     {
-        internal EmpiricalValidator()
+        public EmpiricalValidator()
         {
         }
+        //TODO: Fix these functions. Not fixing now due to higher priorities. -RN
         public IMessageLevels IsValid(Distributions.Empirical entity, out IEnumerable<IMessage> msgs)
         {
             msgs = ReportErrors(entity);

--- a/Statistics/Validation/HistogramValidator.cs
+++ b/Statistics/Validation/HistogramValidator.cs
@@ -9,9 +9,9 @@ using Statistics.Distributions;
 
 namespace Statistics.Validation
 {
-    class HistogramValidator : IValidator<Histograms.Histogram>
+    public class HistogramValidator : IValidator<Histograms.Histogram>
     {
-        internal HistogramValidator()
+        public HistogramValidator()
         {
         }
         public IMessageLevels IsValid(Histograms.Histogram entity, out IEnumerable<IMessage> msgs)

--- a/Statistics/Validation/LogNormalValidator.cs
+++ b/Statistics/Validation/LogNormalValidator.cs
@@ -7,9 +7,9 @@ using Utilities;
 
 namespace Statistics.Validation
 {
-    internal class LogNormalValidator: IValidator<Distributions.LogNormal>
+    public class LogNormalValidator: IValidator<Distributions.LogNormal>
     {
-        internal LogNormalValidator()
+        public LogNormalValidator()
         {
         }
 

--- a/Statistics/Validation/LogPearson3Validator.cs
+++ b/Statistics/Validation/LogPearson3Validator.cs
@@ -7,9 +7,9 @@ using Statistics.Distributions;
 
 namespace Statistics.Validation
 {
-    internal class LogPearson3Validator: IValidator<LogPearson3>
+    public class LogPearson3Validator: IValidator<LogPearson3>
     {
-        internal LogPearson3Validator()
+        public LogPearson3Validator()
         {
         }
 

--- a/Statistics/Validation/NormalValidator.cs
+++ b/Statistics/Validation/NormalValidator.cs
@@ -9,9 +9,9 @@ using Statistics.Distributions;
 
 namespace Statistics.Validation
 {
-    internal class NormalValidator: IValidator<Distributions.Normal>
+    public class NormalValidator: IValidator<Distributions.Normal>
     {
-        internal NormalValidator()
+        public NormalValidator()
         {
         }
 

--- a/Statistics/Validation/SampleStatisticsValidator.cs
+++ b/Statistics/Validation/SampleStatisticsValidator.cs
@@ -5,9 +5,9 @@ using Utilities;
 
 namespace Statistics.Validation
 {
-    internal class SampleStatisticsValidator: Utilities.IValidator<ISampleStatistics>
+    public class SampleStatisticsValidator: Utilities.IValidator<ISampleStatistics>
     {
-        internal SampleStatisticsValidator()
+        public SampleStatisticsValidator()
         {
         }
 

--- a/Statistics/Validation/SummaryStatisticsValidator.cs
+++ b/Statistics/Validation/SummaryStatisticsValidator.cs
@@ -6,7 +6,7 @@ using Utilities;
 
 namespace Statistics.Validation
 {
-    class SummaryStatisticsValidator: IValidator<ISampleStatistics>
+    public class SummaryStatisticsValidator: IValidator<ISampleStatistics>
     {
         public SummaryStatisticsValidator()
         {

--- a/Statistics/Validation/TriangularValidator.cs
+++ b/Statistics/Validation/TriangularValidator.cs
@@ -7,9 +7,9 @@ using System.Linq;
 
 namespace Statistics.Validation
 {
-    internal class TriangularValidator: IValidator<Triangular>
+    public class TriangularValidator: IValidator<Triangular>
     {
-        internal TriangularValidator()
+        public TriangularValidator()
         {
         }
 

--- a/Statistics/Validation/UniformValidator.cs
+++ b/Statistics/Validation/UniformValidator.cs
@@ -6,7 +6,7 @@ using Statistics.Distributions;
 
 namespace Statistics.Validation
 {
-    internal class UniformValidator: IValidator<Uniform>
+    public class UniformValidator: IValidator<Uniform>
     {
         public UniformValidator()
         {


### PR DESCRIPTION
Changed validation to public so we can access the statistics validators in hec-fda and fda-model 